### PR TITLE
Compatibility with Zig 10.0.1

### DIFF
--- a/binding_generator.zig
+++ b/binding_generator.zig
@@ -499,7 +499,7 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
 
                 try std.fmt.format(string.writer(), "        var _bind_args = [_]?*const anyopaque {{{s} }};\n", .{bind_args.items});
 
-                try std.fmt.format(string.writer(), "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, &ret);\n", .{escaped_method_name.items});
+                try std.fmt.format(string.writer(), "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, @ptrCast(?*anyopaque, &ret));\n", .{escaped_method_name.items});
 
                 if (isClassType(return_type)) { //Must use instance binding
                     try string.appendSlice("        if (ret != null) {\n");

--- a/binding_generator.zig
+++ b/binding_generator.zig
@@ -17,8 +17,7 @@ fn toSnakeCase(string: []const u8) String { //Must deinit string
                         snake_case.append('_') catch {};
                         continue;
                     }
-                }
-                else {
+                } else {
                     const previous = string[i - 1];
                     if (std.ascii.isLower(next) and std.ascii.isUpper(previous) and previous != '_') {
                         snake_case.append('_') catch {};
@@ -37,7 +36,7 @@ fn toSnakeCase(string: []const u8) String { //Must deinit string
 
 fn toCamelCase(string: []const u8) String { //Must deinit string
     var camel_case = String.init(std.heap.page_allocator);
-    
+
     var capitalize_next = false;
 
     var i: usize = 0;
@@ -50,8 +49,7 @@ fn toCamelCase(string: []const u8) String { //Must deinit string
         if (capitalize_next) {
             capitalize_next = false;
             camel_case.append(std.ascii.toUpper(char)) catch {};
-        }
-        else {
+        } else {
             camel_case.append(char) catch {};
         }
     }
@@ -63,18 +61,17 @@ fn toCamelCase(string: []const u8) String { //Must deinit string
     return camel_case;
 }
 
-
 fn isEnum(string: []const u8) bool {
     const index = std.mem.indexOf(u8, string, "enum.");
     if (index == null) {
         return false;
     }
-    
+
     return index.? == 0;
 }
 
 fn isPrimitive(string: []const u8) bool {
-    const primitives = [_][]const u8 { "int", "bool", "real", "float", "void" };
+    const primitives = [_][]const u8{ "int", "bool", "real", "float", "void" };
     for (primitives) |primitive| {
         if (std.mem.eql(u8, string, primitive)) {
             return true;
@@ -85,34 +82,7 @@ fn isPrimitive(string: []const u8) bool {
 }
 
 fn isCoreType(string: []const u8) bool {
-    const core_types = [_][]const u8 { 
-        "Array",
-        "Basis",
-        "Color",
-        "Dictionary",
-        "Error",
-        "NodePath",
-        "Plane",
-        "PoolByteArray",
-        "PoolIntArray",
-        "PoolRealArray",
-        "PoolStringArray",
-        "PoolVector2Array",
-        "PoolVector3Array",
-        "PoolColorArray",
-        "PoolIntArray",
-        "PoolRealArray",
-        "Quat",
-        "Rect2",
-        "AABB",
-        "RID",
-        "String",
-        "Transform",
-        "Transform2D",
-        "Variant",
-        "Vector2",
-        "Vector3"
-    };
+    const core_types = [_][]const u8{ "Array", "Basis", "Color", "Dictionary", "Error", "NodePath", "Plane", "PoolByteArray", "PoolIntArray", "PoolRealArray", "PoolStringArray", "PoolVector2Array", "PoolVector3Array", "PoolColorArray", "PoolIntArray", "PoolRealArray", "Quat", "Rect2", "AABB", "RID", "String", "Transform", "Transform2D", "Variant", "Vector2", "Vector3" };
 
     for (core_types) |core| {
         if (std.mem.eql(u8, string, core)) {
@@ -137,13 +107,13 @@ fn stripName(string: []const u8) String { //Must deinit string
 }
 
 fn escapeFunctionName(string: []const u8) String { //Must deinit string
-    const keywords = [_][]const u8 { "align", "resume" };
+    const keywords = [_][]const u8{ "align", "resume" };
 
     var escaped = String.init(std.heap.page_allocator);
 
     for (keywords) |keyword| {
         if (std.mem.eql(u8, string, keyword)) {
-            std.fmt.format(escaped.writer(), "_{s}", .{ string }) catch {};
+            std.fmt.format(escaped.writer(), "_{s}", .{string}) catch {};
             return escaped;
         }
     }
@@ -162,8 +132,7 @@ fn enumGetClass(string: []const u8) String { //Must deinit string //Assumes para
         const identifier_index = std.mem.indexOf(u8, string, "::");
         if (identifier_index != null) {
             converted.appendSlice(string[(class_index.? + 1)..identifier_index.?]) catch {};
-        }
-        else {
+        } else {
             converted.appendSlice(string[(class_index.? + 1)..string.len]) catch {};
         }
     }
@@ -181,8 +150,7 @@ fn enumToZigEnum(string: []const u8) String { //Must deinit string //Assumes par
             converted.appendSlice(string[(class_index.? + 1)..identifier_index.?]) catch {};
             converted.appendSlice(".") catch {};
             converted.appendSlice(string[(identifier_index.? + 2)..string.len]) catch {};
-        }
-        else {
+        } else {
             converted.appendSlice(string[(class_index.? + 1)..string.len]) catch {};
         }
     }
@@ -198,17 +166,13 @@ fn makeGDNativeType(string: []const u8) String { //Must deinit string
         const zig_enum = enumToZigEnum(string);
         defer zig_enum.deinit();
         converted.appendSlice(zig_enum.items) catch {};
-    }
-    else if (isClassType(string)) {
-        std.fmt.format(converted.writer(), "?*{s}", .{ string }) catch {};
-    }
-    else if (std.mem.eql(u8, string, "int")) {
+    } else if (isClassType(string)) {
+        std.fmt.format(converted.writer(), "?*{s}", .{string}) catch {};
+    } else if (std.mem.eql(u8, string, "int")) {
         converted.appendSlice("i64") catch {};
-    }
-    else if (std.mem.eql(u8, string, "float")) {
+    } else if (std.mem.eql(u8, string, "float")) {
         converted.appendSlice("f64") catch {};
-    }
-    else {
+    } else {
         converted.appendSlice(string) catch {};
     }
 
@@ -218,7 +182,7 @@ fn makeGDNativeType(string: []const u8) String { //Must deinit string
 
 fn getUsedClasses(class: *const std.json.ObjectMap) std.StringHashMap(void) { //Must deinit hashmap, key strings too //Names are stripped, CoreTypes not included
     var classes = std.StringHashMap(void).init(std.heap.page_allocator);
-    
+
     const base_class_name = class.get("base_class").?.String;
     if (base_class_name.len > 0) {
         classes.put(base_class_name, {}) catch {};
@@ -228,14 +192,13 @@ fn getUsedClasses(class: *const std.json.ObjectMap) std.StringHashMap(void) { //
     for (methods.items) |item| {
         const method = item.Object;
         const return_type = method.get("return_type").?.String;
-        
+
         if (isEnum(return_type)) {
             const enum_class = enumGetClass(return_type);
             if (!isCoreType(enum_class.items)) {
                 classes.put(enum_class.items, {}) catch {};
             }
-        }
-        else if (isClassType(return_type)) {
+        } else if (isClassType(return_type)) {
             const stripped_class = stripName(return_type);
             classes.put(stripped_class.items, {}) catch {};
         }
@@ -245,13 +208,12 @@ fn getUsedClasses(class: *const std.json.ObjectMap) std.StringHashMap(void) { //
             const argument = arguments_item.Object;
             const arg_type = argument.get("type").?.String;
 
-            if (isEnum(arg_type)){
+            if (isEnum(arg_type)) {
                 const enum_class = enumGetClass(arg_type);
                 if (!isCoreType(enum_class.items)) {
                     classes.put(enum_class.items, {}) catch {};
                 }
-            }
-            else if (isClassType(arg_type)) {
+            } else if (isClassType(arg_type)) {
                 const stripped_class = stripName(arg_type);
                 classes.put(stripped_class.items, {}) catch {};
             }
@@ -260,7 +222,6 @@ fn getUsedClasses(class: *const std.json.ObjectMap) std.StringHashMap(void) { //
 
     return classes;
 }
-
 
 fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit string
     var string = String.init(std.heap.page_allocator);
@@ -343,16 +304,13 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
 
     // Class struct definition
 
-    try std.fmt.format(string.writer(), "pub const {s} = struct {{\n\n", .{ stripped_class_name.items }); // Extra { to escape it
+    try std.fmt.format(string.writer(), "pub const {s} = struct {{\n\n", .{stripped_class_name.items}); // Extra { to escape it
 
-    try std.fmt.format(string.writer(), "    base: {s},\n\n", .{ base_class_name });
+    try std.fmt.format(string.writer(), "    base: {s},\n\n", .{base_class_name});
 
     try string.appendSlice("    const Self = @This();\n\n");
 
-    try std.fmt.format(string.writer(), "    pub const GodotClass = GenGodotClass(Self, {s}, {s});\n", .{ 
-        if (class_is_instanciable) "true" else "false",
-        if (class_is_singleton) "true" else "false"
-    });
+    try std.fmt.format(string.writer(), "    pub const GodotClass = GenGodotClass(Self, {s}, {s});\n", .{ if (class_is_instanciable) "true" else "false", if (class_is_singleton) "true" else "false" });
     try string.appendSlice("    pub usingnamespace GodotClass;\n\n"); // Not necessary, but makes calling its nested functions less verbose
 
     // Enums
@@ -361,7 +319,7 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
     for (enums.items) |enum_item| {
         const class_enum = enum_item.Object;
         const enum_name = class_enum.get("name").?.String;
-        try std.fmt.format(string.writer(), "    pub const {s} = enum(i64) {{\n", .{ enum_name });
+        try std.fmt.format(string.writer(), "    pub const {s} = enum(i64) {{\n", .{enum_name});
 
         const values = class_enum.get("values").?.Object;
         var value_iterator = values.iterator();
@@ -380,7 +338,7 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
     }
 
     // Constants
-    
+
     const constants = class.get("constants").?.Object;
     var const_iterator = constants.iterator();
     while (const_iterator.next()) |entry| {
@@ -409,7 +367,7 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
         const escaped_method_name = escapeFunctionName(method_name);
         defer escaped_method_name.deinit();
 
-        try std.fmt.format(string.writer(), "        {s}: [*c]gd.godot_method_bind,\n", .{ escaped_method_name.items });
+        try std.fmt.format(string.writer(), "        {s}: [*c]gd.godot_method_bind,\n", .{escaped_method_name.items});
     }
 
     try string.appendSlice("    };\n\n");
@@ -427,8 +385,7 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
         const escaped_method_name = escapeFunctionName(method_name);
         defer escaped_method_name.deinit();
 
-        try std.fmt.format(string.writer(), "        binds.{s} = api.core.godot_method_bind_get_method.?(\"{s}\", \"{s}\");\n", 
-            .{ escaped_method_name.items, class_name, method_name });
+        try std.fmt.format(string.writer(), "        binds.{s} = api.core.godot_method_bind_get_method.?(\"{s}\", \"{s}\");\n", .{ escaped_method_name.items, class_name, method_name });
     }
 
     try string.appendSlice("    }\n\n");
@@ -454,12 +411,14 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
             const camel_method_name = toCamelCase(escaped_method_name.items);
             defer camel_method_name.deinit();
 
-            var constness = String.init(std.heap.page_allocator); defer constness.deinit();
+            var constness = String.init(std.heap.page_allocator);
+            defer constness.deinit();
             if (is_const) {
                 try constness.appendSlice("const ");
             }
 
-            var signature_args = String.init(std.heap.page_allocator); defer signature_args.deinit();
+            var signature_args = String.init(std.heap.page_allocator);
+            defer signature_args.deinit();
             for (arguments.items) |arguments_item| {
                 const argument = arguments_item.Object;
 
@@ -477,55 +436,42 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
                 try signature_args.appendSlice(", p_var_args: *const Array");
             }
 
-            try std.fmt.format(string.writer(), "    pub fn {s}(self: *{s}Self{s}) {s} {{\n", 
-                .{ camel_method_name.items, constness.items, signature_args.items, return_gd_type.items });
+            try std.fmt.format(string.writer(), "    pub fn {s}(self: *{s}Self{s}) {s} {{\n", .{ camel_method_name.items, constness.items, signature_args.items, return_gd_type.items });
         }
 
         // Method content
 
         if (has_varargs) {
-            try std.fmt.format(string.writer(), 
-                "        const total_arg_count = {} + p_var_args.size();\n\n", 
-                .{ arguments.items.len });
+            try std.fmt.format(string.writer(), "        const total_arg_count = {} + p_var_args.size();\n\n", .{arguments.items.len});
 
-            try string.appendSlice(
-                "        var _bind_args: [64][*c]gd.godot_variant = undefined;\n\n"); //Should be enough
+            try string.appendSlice("        var _bind_args: [64][*c]gd.godot_variant = undefined;\n\n"); //Should be enough
 
             for (arguments.items) |arguments_item, i| {
                 const argument = arguments_item.Object;
 
                 const arg_name = argument.get("name").?.String;
-                try std.fmt.format(string.writer(), 
-                    "        var _variant_{s} = Variant.init(p_{s});\n" ++ 
-                    "        defer _variant_{s}.deinit();\n" ++ 
-                    "        _bind_args[{}] = &_variant_{s}.godot_variant;\n\n", 
-                    .{ arg_name, arg_name, arg_name, i, arg_name });
+                try std.fmt.format(string.writer(), "        var _variant_{s} = Variant.init(p_{s});\n" ++
+                    "        defer _variant_{s}.deinit();\n" ++
+                    "        _bind_args[{}] = &_variant_{s}.godot_variant;\n\n", .{ arg_name, arg_name, arg_name, i, arg_name });
             }
 
-            try std.fmt.format(string.writer(), 
-                "        var i: usize = 0;\n" ++ 
-                "        while (i < p_var_args.size()) : (i += 1) {{\n" ++ 
-                "            _bind_args[i + {}] = &p_var_args.get(@intCast(i32, i)).godot_variant;\n" ++ 
-                "        }}\n\n",
-                .{ arguments.items.len });
+            try std.fmt.format(string.writer(), "        var i: usize = 0;\n" ++
+                "        while (i < p_var_args.size()) : (i += 1) {{\n" ++
+                "            _bind_args[i + {}] = &p_var_args.get(@intCast(i32, i)).godot_variant;\n" ++
+                "        }}\n\n", .{arguments.items.len});
 
-            try std.fmt.format(string.writer(), 
-                "        const result = api.core.godot_method_bind_call.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, total_arg_count, null);\n\n", 
-                .{ escaped_method_name.items });
+            try std.fmt.format(string.writer(), "        const result = api.core.godot_method_bind_call.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, total_arg_count, null);\n\n", .{escaped_method_name.items});
 
             if (std.mem.eql(u8, return_type, "void")) {
                 try string.appendSlice("        _ = result;\n");
-            }
-            else {
-                try string.appendSlice(
-                    "        const ret = Variant.initGodotVariant(result);\n" ++ 
+            } else {
+                try string.appendSlice("        const ret = Variant.initGodotVariant(result);\n" ++
                     "        return ret;\n");
             }
 
             // Method end
             try string.appendSlice("    }\n\n");
-        }
-        else {
+        } else {
             var bind_args = String.init(std.heap.page_allocator);
             defer bind_args.deinit();
 
@@ -535,10 +481,9 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
                 const arg_name = argument.get("name").?.String;
                 const arg_type = argument.get("type").?.String;
                 if (isClassType(arg_type)) {
-                    try std.fmt.format(bind_args.writer(), " @ptrCast(*Wrapped, p_{s}).owner,", .{ arg_name }); // Trailing comma is fine
-                }
-                else {
-                    try std.fmt.format(bind_args.writer(), " &p_{s},", .{ arg_name }); // Trailing comma is fine
+                    try std.fmt.format(bind_args.writer(), " @ptrCast(*Wrapped, p_{s}).owner,", .{arg_name}); // Trailing comma is fine
+                } else {
+                    try std.fmt.format(bind_args.writer(), " &p_{s},", .{arg_name}); // Trailing comma is fine
                 }
             }
             if (bind_args.items.len == 0) {
@@ -546,34 +491,21 @@ fn generateClass(class: *const std.json.ObjectMap) !String { //Must deinit strin
             }
 
             if (std.mem.eql(u8, return_type, "void")) { //No return
-                try std.fmt.format(string.writer(), 
-                    "        var _bind_args = [_]?*const anyopaque {{{s} }};\n", 
-                    .{ bind_args.items });
-                
-                try std.fmt.format(string.writer(), 
-                    "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, null);\n", 
-                    .{ escaped_method_name.items });
-            }
-            else {
-                try std.fmt.format(string.writer(), 
-                    "        var ret: {s} = undefined;\n", 
-                    .{ return_gd_type.items });
-                    
-                try std.fmt.format(string.writer(), 
-                    "        var _bind_args = [_]?*const anyopaque {{{s} }};\n", 
-                    .{ bind_args.items });
+                try std.fmt.format(string.writer(), "        var _bind_args = [_]?*const anyopaque {{{s} }};\n", .{bind_args.items});
 
-                try std.fmt.format(string.writer(), 
-                    "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, &ret);\n", 
-                    .{ escaped_method_name.items });
-                
+                try std.fmt.format(string.writer(), "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, null);\n", .{escaped_method_name.items});
+            } else {
+                try std.fmt.format(string.writer(), "        var ret: {s} = undefined;\n", .{return_gd_type.items});
+
+                try std.fmt.format(string.writer(), "        var _bind_args = [_]?*const anyopaque {{{s} }};\n", .{bind_args.items});
+
+                try std.fmt.format(string.writer(), "        api.core.godot_method_bind_ptrcall.?(binds.{s}, @intToPtr(*Wrapped, @ptrToInt(self)).owner, &_bind_args, &ret);\n", .{escaped_method_name.items});
+
                 if (isClassType(return_type)) { //Must use instance binding
                     try string.appendSlice("        if (ret != null) {\n");
                     try string.appendSlice("            const instance_data = api.nativescript_1_1.godot_nativescript_get_instance_binding_data.?(api.language_index, ret);\n");
 
-                    try std.fmt.format(string.writer(), 
-                        "            ret = @ptrCast({s}, @alignCast(@alignOf({s}), instance_data));\n", 
-                        .{ return_gd_type.items, return_gd_type.items });
+                    try std.fmt.format(string.writer(), "            ret = @ptrCast({s}, @alignCast(@alignOf({s}), instance_data));\n", .{ return_gd_type.items, return_gd_type.items });
 
                     try string.appendSlice("        }\n");
                 }
@@ -599,14 +531,14 @@ fn generatePackageClassImports(classes: *const std.json.Array) !String { //Must 
     //Imports
     for (classes.items) |item| {
         const class = item.Object;
-        
+
         const class_name = class.get("name").?.String;
         const stripped_name = stripName(class_name);
         defer stripped_name.deinit();
 
         const convention_name = toSnakeCase(stripped_name.items);
         defer convention_name.deinit();
-        
+
         try std.fmt.format(string.writer(), "pub const {s} = @import(\"{s}.zig\");\n", .{ convention_name.items, convention_name.items });
     }
 
@@ -622,14 +554,14 @@ fn generateTypeRegistry(classes: *const std.json.Array) !String { //Must deinit 
     //Imports
     for (classes.items) |item| {
         const class = item.Object;
-        
+
         const class_name = class.get("name").?.String;
         const stripped_name = stripName(class_name);
         defer stripped_name.deinit();
 
         const convention_name = toSnakeCase(stripped_name.items);
         defer convention_name.deinit();
-        
+
         try std.fmt.format(string.writer(), "const {s} = @import(\"{s}.zig\").{s};\n", .{ stripped_name.items, convention_name.items, stripped_name.items });
     }
 
@@ -637,10 +569,10 @@ fn generateTypeRegistry(classes: *const std.json.Array) !String { //Must deinit 
 
     //Registering
     try string.appendSlice("pub fn registerTypes() void {\n");
-    
+
     for (classes.items) |item| {
         const class = item.Object;
-        
+
         const class_name = class.get("name").?.String;
         const stripped_name = stripName(class_name);
         defer stripped_name.deinit();
@@ -648,13 +580,11 @@ fn generateTypeRegistry(classes: *const std.json.Array) !String { //Must deinit 
         const base_class_name = class.get("base_class").?.String;
         const stripped_base_name = stripName(base_class_name);
         defer stripped_base_name.deinit();
-        
+
         if (base_class_name.len == 0) {
-            try std.fmt.format(string.writer(), "    ClassRegistry.registerGlobalType(\"{s}\", typeId({s}), 0);\n", .{ class_name, stripped_name.items});
-        }
-        else {
-            try std.fmt.format(string.writer(), "    ClassRegistry.registerGlobalType(\"{s}\", typeId({s}), typeId({s}));\n", 
-                .{ class_name, stripped_name.items, stripped_base_name.items });
+            try std.fmt.format(string.writer(), "    ClassRegistry.registerGlobalType(\"{s}\", typeId({s}), 0);\n", .{ class_name, stripped_name.items });
+        } else {
+            try std.fmt.format(string.writer(), "    ClassRegistry.registerGlobalType(\"{s}\", typeId({s}), typeId({s}));\n", .{ class_name, stripped_name.items, stripped_base_name.items });
         }
     }
 
@@ -669,7 +599,7 @@ fn generateInitBindings(classes: *const std.json.Array) !String { //Must deinit 
     //Imports
     for (classes.items) |item| {
         const class = item.Object;
-        
+
         const class_name = class.get("name").?.String;
         const stripped_name = stripName(class_name);
         defer stripped_name.deinit();
@@ -692,7 +622,7 @@ fn generateInitBindings(classes: *const std.json.Array) !String { //Must deinit 
         const stripped_name = stripName(class_name);
         defer stripped_name.deinit();
 
-        try std.fmt.format(string.writer(), "    {s}.initBindings();\n", .{ stripped_name.items });
+        try std.fmt.format(string.writer(), "    {s}.initBindings();\n", .{stripped_name.items});
     }
 
     try string.appendSlice("}\n");
@@ -714,7 +644,7 @@ pub fn generateClassBindings(api_path: []const u8) !void {
     defer tree.deinit();
 
     const gen_dir = try std.fs.cwd().makeOpenPath("src/classes", .{});
-    
+
     for (tree.root.Array.items) |item| {
         const class = item.Object;
 
@@ -763,8 +693,7 @@ pub fn generateClassBindings(api_path: []const u8) !void {
     }
 }
 
-
-const c_primitives = [_][2][]const u8 {
+const c_primitives = [_][2][]const u8{
     .{ "void", "void" },
     .{ "bool", "bool" },
     .{ "char", "u8" },
@@ -811,8 +740,7 @@ fn convertGDNativeType(gdnative_type: []const u8) String { //Must deinit string
     var type_end_index = gdnative_type.len;
     if (ptr_index != null) {
         type_end_index = ptr_index.?;
-    }
-    else {
+    } else {
         const other_ptr_index = std.mem.indexOf(u8, gdnative_type, "*");
         if (other_ptr_index != null) {
             type_end_index = other_ptr_index.?;
@@ -822,26 +750,20 @@ fn convertGDNativeType(gdnative_type: []const u8) String { //Must deinit string
     //Zig expects void*/anyopaque to use ?*
     const base_type = gdnative_type[type_start_index..type_end_index];
     const is_void = std.mem.eql(u8, base_type, "void");
-    const is_anyopaque_ptr = ptr_index != null and (
-        is_void or
-        std.mem.eql(u8, base_type, "godot_object")
-    );
+    const is_anyopaque_ptr = ptr_index != null and (is_void or
+        std.mem.eql(u8, base_type, "godot_object"));
 
     //Convert ptr
     if (std.mem.indexOfPos(u8, gdnative_type, type_end_index, "**") != null) {
         if (is_anyopaque_ptr) {
             string.appendSlice("[*c]?*") catch {};
-        }
-        else {
+        } else {
             string.appendSlice("[*c][*c]") catch {};
         }
-        
-    }
-    else if (ptr_index != null) {
+    } else if (ptr_index != null) {
         if (is_anyopaque_ptr) {
             string.appendSlice("?*") catch {};
-        }
-        else {
+        } else {
             string.appendSlice("[*c]") catch {};
         }
     }
@@ -853,14 +775,12 @@ fn convertGDNativeType(gdnative_type: []const u8) String { //Must deinit string
 
     if (is_void and ptr_index != null) {
         string.appendSlice("anyopaque") catch {};
-    }
-    else {
+    } else {
         const result = isCPrimitive(base_type);
         if (result != null) {
             string.appendSlice(c_primitives[result.?][1]) catch {};
-        }
-        else {
-            std.fmt.format(string.writer(), "gd.{s}", .{ base_type }) catch {};
+        } else {
+            std.fmt.format(string.writer(), "gd.{s}", .{base_type}) catch {};
         }
     }
 
@@ -881,34 +801,27 @@ fn writeAPI(api: *const std.json.ObjectMap, string: *String, is_core: bool, is_r
 
     if (is_core) {
         if (is_root) {
-            std.fmt.format(name.writer(), "godot_gdnative_{s}_api_struct", .{ api_name_name_converted.items }) catch {};
-        }
-        else {
+            std.fmt.format(name.writer(), "godot_gdnative_{s}_api_struct", .{api_name_name_converted.items}) catch {};
+        } else {
             std.fmt.format(name.writer(), "godot_gdnative_{s}_{}_{}_api_struct", .{ api_name_name_converted.items, major, minor }) catch {};
         }
-    }
-    else {
+    } else {
         if (is_root) {
-            std.fmt.format(name.writer(), "godot_gdnative_ext_{s}_api_struct", .{ api_name_name_converted.items }) catch {};
-        }
-        else {
+            std.fmt.format(name.writer(), "godot_gdnative_ext_{s}_api_struct", .{api_name_name_converted.items}) catch {};
+        } else {
             std.fmt.format(name.writer(), "godot_gdnative_ext_{s}_{}_{}_api_struct", .{ api_name_name_converted.items, major, minor }) catch {};
         }
     }
 
-    std.fmt.format(string.writer(), "pub const {s} = extern struct {{\n", .{ name.items }) catch {}; //API Struct begin
+    std.fmt.format(string.writer(), "pub const {s} = extern struct {{\n", .{name.items}) catch {}; //API Struct begin
 
-    string.appendSlice(
-        "    type: c_uint,\n" ++
+    string.appendSlice("    type: c_uint,\n" ++
         "    version: gd.godot_gdnative_api_version,\n" ++
-        "    next: [*c]const gd.godot_gdnative_api_struct,\n"
-    ) catch {};
+        "    next: [*c]const gd.godot_gdnative_api_struct,\n") catch {};
 
     if (is_core and is_root) {
-        string.appendSlice(
-            "    num_extensions: c_uint,\n" ++
-            "    extensions: [*c][*c]const gd.godot_gdnative_api_struct,\n"
-        ) catch {};
+        string.appendSlice("    num_extensions: c_uint,\n" ++
+            "    extensions: [*c][*c]const gd.godot_gdnative_api_struct,\n") catch {};
     }
 
     const api_functions = api.get("api").?.Array;
@@ -932,10 +845,9 @@ fn writeAPI(api: *const std.json.ObjectMap, string: *String, is_core: bool, is_r
             defer converted_arg_type.deinit();
 
             if (i < arguments.items.len - 1) {
-                std.fmt.format(converted_args.writer(), "{s}, ", .{ converted_arg_type.items }) catch {};
-            }
-            else {
-                std.fmt.format(converted_args.writer(), "{s}", .{ converted_arg_type.items }) catch {};
+                std.fmt.format(converted_args.writer(), "{s}, ", .{converted_arg_type.items}) catch {};
+            } else {
+                std.fmt.format(converted_args.writer(), "{s}", .{converted_arg_type.items}) catch {};
             }
         }
 
@@ -981,7 +893,7 @@ pub fn generateGDNativeAPI(api_path: []const u8) !void {
 
     const core = tree.root.Object.get("core").?.Object;
     writeAPI(&core, &gdnative_api_string, true, true);
-    
+
     const extensions = tree.root.Object.get("extensions").?.Array;
     for (extensions.items) |extension_item| {
         const extension = extension_item.Object;

--- a/binding_generator.zig
+++ b/binding_generator.zig
@@ -854,7 +854,7 @@ fn writeAPI(api: *const std.json.ObjectMap, string: *String, is_core: bool, is_r
         var converted_return_type = convertGDNativeType(return_type);
         defer converted_return_type.deinit();
 
-        std.fmt.format(string.writer(), "    {s}: ?fn ({s}) callconv(.C) {s},\n", .{ function_name, converted_args.items, converted_return_type.items }) catch {};
+        std.fmt.format(string.writer(), "    {s}: ?*fn ({s}) callconv(.C) {s},\n", .{ function_name, converted_args.items, converted_return_type.items }) catch {};
     }
 
     string.appendSlice("};\n\n") catch {}; //API Struct end


### PR DESCRIPTION
i made some commits to fix some problems when i tried to generate bindings using zig version 10.0. and godot 3.5.2.

**-> Changes :**

- I changed the type of the `ret` variable in the `getChild` function from `?*Node` to `anyopaque`, and I also updated the call to the `godot_method_bind_ptrcall` function to use a pointer to `anyopaque` for the `ret` argument. This avoids the issue of implicitly casting `*?*Node` to `?*anyopaque`.

- I also changed `{s}: *fn ({s}) callconv(.C) {s}` to `{s}: ?*fn ({s}) callconv(.C) {s}` 